### PR TITLE
Update server API

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ require 'h2/server'
 
 server = H2::Server::HTTP.new host: addr, port: port do |connection|
   connection.each_stream do |stream|
-    stream.respond :ok, "hello, world!\n"
+    stream.respond status: 200, body: "hello, world!\n"
     stream.connection.goaway
   end
 end

--- a/examples/server/hello_world.rb
+++ b/examples/server/hello_world.rb
@@ -12,7 +12,7 @@ addr, port = '127.0.0.1', 1234
 puts "*** Starting server on http://#{addr}:#{port}"
 s = H2::Server::HTTP.new host: addr, port: port do |connection|
   connection.each_stream do |stream|
-    stream.respond :ok, "hello, world!\n"
+    stream.respond status: 200, body: "hello, world!\n"
     stream.connection.goaway
   end
 end

--- a/examples/server/https_hello_world.rb
+++ b/examples/server/https_hello_world.rb
@@ -21,9 +21,9 @@ s = H2::Server::HTTPS.new host: addr, port: port, **tls do |connection|
     stream.goaway_on_complete
 
     if stream.request.path == '/favicon.ico'
-      stream.respond :not_found
+      stream.respond status: 404
     else
-      stream.respond :ok, "hello, world!\n"
+      stream.respond status: 200, body: "hello, world!\n"
     end
   end
 end

--- a/lib/h2/server/stream.rb
+++ b/lib/h2/server/stream.rb
@@ -40,32 +40,13 @@ module H2
         bind_events
       end
 
-      # mimicing Reel::Connection#respond
+      # write status, headers, and body to +@stream+
       #
-      # write status, headers, and data to +@stream+
-      #
-      def respond response, body_or_headers = nil, body = nil
-
-        # :/
-        #
-        if Hash === body_or_headers
-          headers = body_or_headers
-          body ||= ''
-        else
-          headers = {}
-          body = body_or_headers ||= ''
-        end
-
-        @response = case response
-                    when Symbol, Integer
-                      response = Response.new stream: self,
-                                              status: response,
-                                              headers: headers,
-                                              body: body
-                    when Response
-                      response
-                    else raise TypeError, "invalid response: #{response.inspect}"
-                    end
+      def respond status:, headers: {}, body: ''
+        response = Response.new stream: self,
+                                status: status,
+                                headers: headers,
+                                body: body
 
         if @closed
           log :warn, 'stream closed before response sent'
@@ -85,20 +66,9 @@ module H2
         @connection.server.async.handle_push_promise pp
       end
 
-      # create a push promise - mimicing Reel::Connection#respond
+      # create a push promise
       #
-      def push_promise_for path, body_or_headers = {}, body = nil
-
-        # :/
-        #
-        case body_or_headers
-        when Hash
-          headers = body_or_headers
-        else
-          headers = {}
-          body = body_or_headers
-        end
-
+      def push_promise_for path:, headers: {}, body: nil
         headers.merge! AUTHORITY_KEY => @request.authority,
                        SCHEME_KEY    => @request.scheme
 

--- a/lib/h2/server/stream/request.rb
+++ b/lib/h2/server/stream/request.rb
@@ -55,8 +55,8 @@ module H2
 
         # respond to this request on its stream
         #
-        def respond response, body_or_headers = nil, body = nil
-          @stream.respond response, body_or_headers, body
+        def respond status:, headers: {}, body: ''
+          @stream.respond status: status, headers: headers, body: body
         end
 
       end

--- a/test/h2/server/http_test.rb
+++ b/test/h2/server/http_test.rb
@@ -25,7 +25,7 @@ class HTTPTest < H2::WithServerHandlerTest
         @valid.tap
       rescue => ex
       ensure
-        stream.respond :ok
+        stream.respond status: 200
         stream.connection.goaway
       end
     end
@@ -46,7 +46,7 @@ class HTTPTest < H2::WithServerHandlerTest
     2.times { @valid.expect :tap, nil }
 
     handler = proc do |stream|
-      stream.respond :ok, {'test-header' => 'test_value'}, 'test_body'
+      stream.respond status: :ok, headers: {'test-header' => 'test_value'}, body: 'test_body'
       stream.connection.goaway
       @valid.tap
     end
@@ -69,7 +69,7 @@ class HTTPTest < H2::WithServerHandlerTest
     (@connections * 2).times { @valid.expect :tap, nil }
 
     handler = proc do |stream|
-      stream.respond :ok
+      stream.respond status: 200
       stream.connection.goaway
       @valid.tap
     end
@@ -104,7 +104,7 @@ class HTTPTest < H2::WithServerHandlerTest
 
     handler = proc do |stream|
       count -= 1
-      stream.respond :ok
+      stream.respond status: 200
       stream.connection.goaway if count == 0
       @valid.tap
     end
@@ -127,7 +127,7 @@ class HTTPTest < H2::WithServerHandlerTest
     handler = proc do |stream|
       conn = stream.connection
       count[conn] -= 1
-      stream.respond :ok
+      stream.respond status: 200
       @valid.tap
       conn.goaway if count[conn] == 0
     end

--- a/test/h2/server/https_test.rb
+++ b/test/h2/server/https_test.rb
@@ -18,7 +18,7 @@ class HTTPSTest < H2::WithServerHandlerTest
 
   def with_tls_server handler = nil
     handler ||= proc do |stream|
-      stream.respond :ok
+      stream.respond status: 200
       stream.connection.goaway
     end
 
@@ -70,7 +70,7 @@ class HTTPSTest < H2::WithServerHandlerTest
         @valid.tap
       rescue => ex
       ensure
-        stream.respond :ok, 'boo'
+        stream.respond status: 200, body: 'boo'
         stream.connection.goaway
       end
     end
@@ -108,7 +108,7 @@ class HTTPSTest < H2::WithServerHandlerTest
             @valid.tap
           rescue => ex
           ensure
-            stream.respond :ok, 'boo'
+            stream.respond status: 200, body: 'boo'
             stream.connection.goaway
           end
         end

--- a/test/h2/server/push_promise_test.rb
+++ b/test/h2/server/push_promise_test.rb
@@ -11,8 +11,8 @@ class PushPromiseTest < H2::WithServerHandlerTest
         stream.connection.goaway
         @valid.tap
       end
-      stream.push_promise '/push', 'promise'
-      stream.respond :ok
+      stream.push_promise path: '/push', body: 'promise'
+      stream.respond status: 200
     end
 
     with_server handler do
@@ -37,9 +37,9 @@ class PushPromiseTest < H2::WithServerHandlerTest
         stream.connection.goaway
         @valid.tap
       end
-      pp = stream.push_promise_for '/push', 'promise'
+      pp = stream.push_promise_for path: '/push', body: 'promise'
       pp.make_on stream
-      stream.respond :ok
+      stream.respond status: 200
       pp.keep_async
     end
 
@@ -67,9 +67,9 @@ class PushPromiseTest < H2::WithServerHandlerTest
           stream.connection.goaway
           @valid.tap
         end
-        pp = stream.push_promise_for '/push', {'etag' => '1234'}, 'promise'
+        pp = stream.push_promise_for path: '/push', headers: {'etag' => '1234'}, body: 'promise'
         pp.make_on stream
-        stream.respond :ok
+        stream.respond status: 200
         Celluloid.sleep 1 # wait for client to cancel
         refute pp.keep
         assert pp.canceled?

--- a/test/h2/server/stream/request_test.rb
+++ b/test/h2/server/stream/request_test.rb
@@ -6,7 +6,9 @@ class RequestTest < Minitest::Test
   def test_construction_and_basic_api
     s = Minitest::Mock.new
     s.expect :connection, nil
-    s.expect :respond, nil, [:ok, 1, 2]
+    s.expect :respond, nil do |status:, headers:, body:|
+      status == 200 && headers == {} && body == ''
+    end
     s.expect :==, true, [s]
     r = H2::Server::Stream::Request.new s
     assert_equal s, r.stream
@@ -17,7 +19,7 @@ class RequestTest < Minitest::Test
     assert_nil r.addr
     assert_nil r.method
     assert_nil r.path
-    r.respond :ok, 1, 2
+    r.respond status: 200, headers: {}, body: ''
     s.verify
   end
 

--- a/test/h2/stream_test.rb
+++ b/test/h2/stream_test.rb
@@ -32,7 +32,7 @@ class H2::StreamTest < H2::WithServerTest
     @stream = @client.get path: '/'
     @stream.block!
     assert @stream.ok?
-    self.handler = ->(s){ s.respond :not_found; s.connection.goaway }
+    self.handler = ->(s){ s.respond status: 404; s.connection.goaway }
     s = @client.get path: '/'
     s.block!
     refute s.ok?
@@ -42,7 +42,7 @@ class H2::StreamTest < H2::WithServerTest
     mutex = Mutex.new
     condition = ConditionVariable.new
     self.handler = proc do |s|
-      s.respond :ok
+      s.respond status: 200
       s.connection.goaway
       sleep 0.25
       mutex.synchronize { condition.signal }

--- a/test/h2_test.rb
+++ b/test/h2_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require File.expand_path '../test_helper', __FILE__
 
 class H2Test < Minitest::Test
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,7 +39,7 @@ module H2
           else
             go = with_reel_test.verify headers: stream.request.headers,
                                        body: stream.request.body
-            stream.respond :ok
+            stream.respond status: 200
             connection.goaway if go
           end
         end
@@ -92,7 +92,7 @@ module H2
 
     def with_server handler = nil, &block
       handler ||= proc do |stream|
-        stream.respond :ok
+        stream.respond status: 200
         stream.connection.goaway
       end
 


### PR DESCRIPTION
old code was mimicking reel, written in a time before ruby had kwargs. this provides a much cleaner response and push promise API.