### PR TITLE
change Client addr: kwarg to host: to match Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ client.closed? #=> true
 # --- normal connection
 #
 
-client = H2::Client.new addr: 'example.com', port: 443
+client = H2::Client.new host: 'example.com', port: 443
 
 stream = client.get path: '/'
 
@@ -103,7 +103,7 @@ If you're running on macOS and using Homebrew's openssl package, you may need to
 specify the CA file in the TLS options:
 
 ```ruby
-client = H2::Client.new addr: 'example.com', port: 443, tls: { ca_file: '/usr/local/etc/openssl/cert.pem' }
+client = H2::Client.new host: 'example.com', port: 443, tls: { ca_file: '/usr/local/etc/openssl/cert.pem' }
 ```
 
 or when using the CLI:

--- a/lib/h2.rb
+++ b/lib/h2.rb
@@ -38,7 +38,7 @@ module H2
 
     private
 
-    def request addr: nil,
+    def request host: nil,
                 port: nil,
                 method:,
                 path: '/',
@@ -49,14 +49,14 @@ module H2
                 tls: {},
                 &block
 
-      raise ArgumentError if url.nil? && (addr.nil? || port.nil?)
+      raise ArgumentError if url.nil? && (host.nil? || port.nil?)
       if url
         url = URI.parse url unless URI === url
-        addr = url.host
+        host = url.host
         port = url.port
         path = url.request_uri
       end
-      c = Client.new addr: addr, port: port, tls: tls
+      c = Client.new host: host, port: port, tls: tls
       c.__send__ method, path: path, headers: headers, params: params, body: body, &block
     end
   end

--- a/test/h2/client/tcp_socket_test.rb
+++ b/test/h2/client/tcp_socket_test.rb
@@ -2,9 +2,9 @@ require File.expand_path '../../../test_helper', __FILE__
 
 class H2::Client::TCPSocketTest < Minitest::Test
 
-  def with_socket_pair addr: '127.0.0.1', port: 45670
-    server = TCPServer.new addr, port
-    client = H2::Client::TCPSocket.new addr, port
+  def with_socket_pair host: '127.0.0.1', port: 45670
+    server = TCPServer.new host, port
+    client = H2::Client::TCPSocket.new host, port
     peer = server.accept
     yield peer, client
   ensure
@@ -23,7 +23,7 @@ class H2::Client::TCPSocketTest < Minitest::Test
 
   unless ENV['TRAVIS'] == 'true'
     def test_ipv6
-      with_socket_pair addr: '::1' do |peer, client|
+      with_socket_pair host: '::1' do |peer, client|
         refute client.closed?
         assert client.local_address.ipv6?
         assert_equal ::Socket::AF_INET6, client.local_address.afamily

--- a/test/h2/client/tls_test.rb
+++ b/test/h2/client/tls_test.rb
@@ -26,7 +26,7 @@ class H2::Client::TLSTest < Minitest::Test
     tcp_server = TCPServer.new '127.0.0.1', 45670
     server = OpenSSL::SSL::SSLServer.new tcp_server, ctx
     st = Thread.new { c = server.accept rescue nil }
-    H2::Client.new addr: '127.0.0.1', port: 45670 rescue nil
+    H2::Client.new host: '127.0.0.1', port: 45670 rescue nil
     server.close
     assert flag, 'servername_cb should not have been called!'
   end
@@ -39,7 +39,7 @@ class H2::Client::TLSTest < Minitest::Test
       tcp_server = TCPServer.new '::1', 45670
       server = OpenSSL::SSL::SSLServer.new tcp_server, ctx
       st = Thread.new { c = server.accept rescue nil }
-      H2::Client.new addr: '::1', port: 45670 rescue nil
+      H2::Client.new host: '::1', port: 45670 rescue nil
       server.close
       assert flag, 'servername_cb should not have been called!'
     end

--- a/test/h2/server/http_test.rb
+++ b/test/h2/server/http_test.rb
@@ -4,7 +4,7 @@ class HTTPTest < H2::WithServerHandlerTest
 
   def test_accepts_tcp_connections
     with_server do
-      s = TCPSocket.new @addr, @port
+      s = TCPSocket.new @host, @port
       refute s.closed?
       s.close
     end
@@ -79,7 +79,7 @@ class HTTPTest < H2::WithServerHandlerTest
     with_server handler do
       clients = Array.new(@connections).map do
         mutex.synchronize do
-          c = H2::Client.new addr: @addr, port: @port, tls: false
+          c = H2::Client.new host: @host, port: @port, tls: false
           c.get path: '/'
           c
         end
@@ -110,7 +110,7 @@ class HTTPTest < H2::WithServerHandlerTest
     end
 
     with_server handler do
-      c = H2::Client.new addr: @addr, port: @port, tls: false
+      c = H2::Client.new host: @host, port: @port, tls: false
       @streams.times { c.get path: '/' }
       c.block!
       assert_equal 0, count
@@ -133,7 +133,7 @@ class HTTPTest < H2::WithServerHandlerTest
     end
 
     with_server handler do
-      clients = Array.new(@connections).map { H2::Client.new addr: @addr, port: @port, tls: false }
+      clients = Array.new(@connections).map { H2::Client.new host: @host, port: @port, tls: false }
       clients.each {|c| @streams.times { c.get path: '/' }}
       clients.each &:block!
       count.each {|_,v| assert_equal 0, v }

--- a/test/h2/server/https_test.rb
+++ b/test/h2/server/https_test.rb
@@ -23,7 +23,7 @@ class HTTPSTest < H2::WithServerHandlerTest
     end
 
     begin
-      server = H2::Server::HTTPS.new host: @addr, port: @port, cert: @server_cert, key: @server_key do |c|
+      server = H2::Server::HTTPS.new host: @host, port: @port, cert: @server_cert, key: @server_key do |c|
         c.each_stream &handler
       end
       yield server
@@ -34,7 +34,7 @@ class HTTPSTest < H2::WithServerHandlerTest
 
   def test_accept_tcp_connections
     with_tls_server do
-      s = TCPSocket.new @addr, @port
+      s = TCPSocket.new @host, @port
       refute s.closed?
       s.close
     end
@@ -42,7 +42,7 @@ class HTTPSTest < H2::WithServerHandlerTest
 
   def test_accept_tls_1_2_connections
     with_tls_server do
-      s = TCPSocket.new @addr, @port
+      s = TCPSocket.new @host, @port
       ctx = OpenSSL::SSL::SSLContext.new
 
       # https://github.com/jruby/jruby-openssl/issues/99
@@ -53,7 +53,7 @@ class HTTPSTest < H2::WithServerHandlerTest
       ctx.verify_mode = OpenSSL::SSL::VERIFY_PEER
       s = OpenSSL::SSL::SSLSocket.new s, ctx
       s.sync_close = true
-      s.hostname = @addr
+      s.hostname = @host
       s.connect
       refute s.closed?
       s.close

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,11 +28,11 @@ module H2
     end
 
     def setup
-      @addr = '127.0.0.1'
+      @host = '127.0.0.1'
       @port = 45670
       with_reel_test = self
 
-      @server = H2::Server::HTTP.new host: @addr, port: @port do |connection|
+      @server = H2::Server::HTTP.new host: @host, port: @port do |connection|
         connection.each_stream do |stream|
           if with_reel_test.handler
             with_reel_test.handler[stream]
@@ -44,7 +44,7 @@ module H2
           end
         end
       end
-      @client = H2::Client.new addr: @addr, port: @port, tls: false
+      @client = H2::Client.new host: @host, port: @port, tls: false
     end
 
     def teardown
@@ -80,9 +80,9 @@ module H2
 
   class WithServerHandlerTest < Minitest::Test
     def setup
-      @addr = '127.0.0.1'
+      @host = '127.0.0.1'
       @port = 1234
-      @url  = "http://#{@addr}:#{@port}"
+      @url  = "http://#{@host}:#{@port}"
 
       @streams = ENV['STREAMS'] ? Integer(ENV['STREAMS']) : 5
       @connections = ENV['CONNECTIONS'] ? Integer(ENV['CONNECTIONS']) : 32
@@ -99,7 +99,7 @@ module H2
       block ||= ->{ H2.get url: @url, tls: false }
 
       begin
-        server = H2::Server::HTTP.new host: @addr, port: @port, spy: false do |c|
+        server = H2::Server::HTTP.new host: @host, port: @port, spy: false do |c|
           c.each_stream &handler
         end
         block[server]


### PR DESCRIPTION
* unifies on `host:` kwarg
* updates readme and tests